### PR TITLE
Add convenience Witness.fromHexArray method

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ Returns a ScriptSig object
 
 Returns the hexadecimal representation of the Witness object
 
+#### static fromHexArray([hex_wit_sig, hex_wit_pk])
+
+Returns a Witness object from an array of hexadecimal strings representing the siganture and the public key
+
 ## `btcnodejs.Sequence`
 
 Sequence object representing the sequence number of a transaction Input

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -569,6 +569,13 @@ class Witness {
   constructor(data) {
     this.data = data;
   }
+  static fromHexArray(hexs) {
+    let data = [];
+    _.forEach(hexs, hex => {
+      data.push(new ByteBuffer.fromHex(hex));
+    });
+    return new Witness(data);
+  }
   serialize() {
     let dim = 0;
     _.forEach(this.data, data => {

--- a/test/test.js
+++ b/test/test.js
@@ -2300,7 +2300,7 @@ describe("Structs", function() {
         }
       }
     });
-    it("can compute the segwit digest  of its inputs", function() {
+    it("can compute the segwit digest of its inputs", function() {
       for (var i = 0; i < segwit_data.length; i++) {
         let unsigned = transaction.Transaction.fromHex(segwit_data[i]["unsigned_tx"]);
         for (var j = 0; j < segwit_data[i]["txins"].length; j++) {
@@ -2340,6 +2340,22 @@ describe("Structs", function() {
         const bh = BlockHeader.fromHex(blocks[i]["raw"]);
         assert.equal(bh.blockHash(), blocks[i]["hash"]);
       }
+    });
+  });
+
+  describe("Witness", function() {
+    it("can be created fromHexArray", function() {
+      let hexData = [
+        "3045022100ebeb625c62d618c097fb1d54fef8bd3f57698bac191adca0a552725e" +
+        "4f577afc022001814513b04c272c5c86c4a37dd55700be543dc5732db5176dce37" +
+        "7f954bd88401"
+        ,
+        "03f5b78846b3420430e455df568e4bee061827704c36163699544a0e60660fb7cb"
+      ]
+      let witness = new transaction.Witness(
+        hexData.map((hex) => new ByteBuffer.fromHex(hex))
+      );
+      assert.equal(witness.toHex(), transaction.Witness.fromHexArray(hexData).toHex());
     });
   });
 


### PR DESCRIPTION
Minor but the other Structs have a `fromHex` method.  The test is probably overkill but :man_shrugging: 