### PR TITLE
Use Integer for deserialized Output

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -220,7 +220,7 @@ class Transaction {
 
     static deserialize_output(buffer, offset) {
         let i_offset = offset;
-        const amount = buffer.readInt64(offset);
+        const amount = buffer.readInt64(offset).toNumber();
         offset += 8;
         const script_len = buffer.parseVarint(offset);
         offset += script_len.length;


### PR DESCRIPTION
`readInt64` returns a Long
https://github.com/dcodeIO/bytebuffer.js/blob/fbefed78513615946731c059e2597732adde0d97/externs/bytebuffer.js#L405